### PR TITLE
Bugfix: PredictionColumn does the have correct number of classes

### DIFF
--- a/meerkat/columns/prediction_column.py
+++ b/meerkat/columns/prediction_column.py
@@ -124,7 +124,7 @@ class ClassificationOutputColumn(TensorColumn, CloneableMixin):
                             "and have at least 2 dimensions - (N, C, ...)"
                         )
                     one_hot = True
-                num_classes = data.shape[1] if multi_label else torch.max(data)
+                num_classes = data.shape[1] if multi_label else torch.max(data) + 1
 
         self._ctype = _ClassifierOutputType.get_ctype(ctype)
         self.num_classes = int(num_classes)

--- a/tests/mosaic/columns/test_prediction_column.py
+++ b/tests/mosaic/columns/test_prediction_column.py
@@ -44,6 +44,9 @@ class TestClassificationOutputColumn(unittest.TestCase):
         with self.assertRaises(ValueError):
             pred_col.probabilities()
 
+        assert logit_col.num_classes == prob_col.num_classes
+        assert logit_col.num_classes == pred_col.num_classes
+
     def test_bincount(self):
         col = ClassificationOutputColumn(logits=logits)
         expected_bincount = torch.as_tensor([1, 0, 0, 1, 2])


### PR DESCRIPTION
Fix logic for prediction column not having correct number of classes. Note `0` is treated as a class index, so number of classes are `max(pred) + 1`

Closes #92 