### PR TITLE
Support overwriting old manager when writing

### DIFF
--- a/meerkat/block/manager.py
+++ b/meerkat/block/manager.py
@@ -214,9 +214,9 @@ class BlockManager(MutableMapping):
         # prepare directories
         os.makedirs(path, exist_ok=True)
         block_dirs = os.path.join(path, "blocks")
-        os.makedirs(block_dirs)
+        os.makedirs(block_dirs, exist_ok=True)
         columns_dir = os.path.join(path, "columns")
-        os.makedirs(columns_dir)
+        os.makedirs(columns_dir, exist_ok=True)
 
         # consolidate before writing
         self.consolidate()

--- a/meerkat/block/manager.py
+++ b/meerkat/block/manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 from collections import defaultdict
 from collections.abc import MutableMapping
 from typing import Dict, Mapping, Sequence, Union
@@ -212,17 +213,35 @@ class BlockManager(MutableMapping):
         }
 
         # prepare directories
-        os.makedirs(path, exist_ok=True)
-        block_dirs = os.path.join(path, "blocks")
-        os.makedirs(block_dirs, exist_ok=True)
         columns_dir = os.path.join(path, "columns")
-        os.makedirs(columns_dir, exist_ok=True)
+        blocks_dir = os.path.join(path, "blocks")
+        meta_path = os.path.join(path, "meta.yaml")
+        if os.path.isdir(path):
+            if (
+                os.path.exists(meta_path)
+                and os.path.exists(columns_dir)
+                and os.path.exists(blocks_dir)
+            ):
+                # if overwriting, ensure that old columns are removed
+                shutil.rmtree(columns_dir)
+                shutil.rmtree(blocks_dir)
+            else:
+                # if path already points to a dir that wasn't previously holding a
+                # block manager, do not overwrite it. We'd like to protect against
+                # situation in which user accidentally puts in an important directory
+                raise IsADirectoryError(
+                    f"Cannot write `BlockManager`. {path} is a directory."
+                )
+
+        os.makedirs(path, exist_ok=True)
+        os.makedirs(blocks_dir)
+        os.makedirs(columns_dir)
 
         # consolidate before writing
         self.consolidate()
         for block_id, block_ref in self._block_refs.items():
             block: AbstractBlock = block_ref.block
-            block_dir = os.path.join(block_dirs, str(block_id))
+            block_dir = os.path.join(blocks_dir, str(block_id))
             block.write(block_dir)
 
             for name, column in block_ref.items():
@@ -247,7 +266,6 @@ class BlockManager(MutableMapping):
             column.write(os.path.join(columns_dir, name))
 
         # Save the metadata as a yaml file
-        meta_path = os.path.join(path, "meta.yaml")
         yaml.dump(meta, open(meta_path, "w"))
 
     @classmethod

--- a/meerkat/datapanel.py
+++ b/meerkat/datapanel.py
@@ -786,7 +786,6 @@ class DataPanel(
 
         # write the block manager
         mgr_dir = os.path.join(path, "mgr")
-        os.makedirs(mgr_dir, exist_ok=True)
         self.data.write(mgr_dir)
 
         # Write the state

--- a/tests/meerkat/block/test_manager.py
+++ b/tests/meerkat/block/test_manager.py
@@ -294,3 +294,17 @@ def test_io(tmpdir):
 
     for idx in range(7, 8):
         assert mgr[f"col{idx}"].data == new_mgr[f"col{idx}"].data
+
+    col1 = mk.NumpyArrayColumn(data=np.arange(10) * 100)
+    mgr.add_column(col1, "col1")
+
+    # test overwriting
+    mgr.write(tmpdir)
+    new_mgr = BlockManager.read(tmpdir)
+    assert len(new_mgr._block_refs) == 3
+
+    for idx in range(1, 7):
+        assert (mgr[f"col{idx}"] == new_mgr[f"col{idx}"]).all()
+
+    for idx in range(7, 8):
+        assert mgr[f"col{idx}"].data == new_mgr[f"col{idx}"].data

--- a/tests/meerkat/block/test_manager.py
+++ b/tests/meerkat/block/test_manager.py
@@ -1,3 +1,4 @@
+import os
 from itertools import product
 
 import numpy as np
@@ -263,6 +264,7 @@ def test_len(num_blocks, consolidated):
 
 
 def test_io(tmpdir):
+    tmpdir = os.path.join(tmpdir, "test")
     mgr = BlockManager()
 
     col1 = mk.NumpyArrayColumn(data=np.arange(10))
@@ -295,11 +297,14 @@ def test_io(tmpdir):
     for idx in range(7, 8):
         assert mgr[f"col{idx}"].data == new_mgr[f"col{idx}"].data
 
+    # test overwriting
     col1 = mk.NumpyArrayColumn(data=np.arange(10) * 100)
     mgr.add_column(col1, "col1")
-
-    # test overwriting
+    mgr.remove("col9")
+    assert os.path.exists(os.path.join(tmpdir, "columns", "col9"))
     mgr.write(tmpdir)
+    # make sure the old column was removed
+    assert not os.path.exists(os.path.join(tmpdir, "columns", "col9"))
     new_mgr = BlockManager.read(tmpdir)
     assert len(new_mgr._block_refs) == 3
 
@@ -308,3 +313,15 @@ def test_io(tmpdir):
 
     for idx in range(7, 8):
         assert mgr[f"col{idx}"].data == new_mgr[f"col{idx}"].data
+
+
+def test_io_no_overwrite(tmpdir):
+    new_dir = os.path.join(tmpdir, "test")
+    os.mkdir(new_dir)
+    mgr = BlockManager()
+
+    with pytest.raises(
+        IsADirectoryError,
+        match=f"Cannot write `BlockManager`. {new_dir} is a directory.",
+    ):
+        mgr.write(new_dir)


### PR DESCRIPTION
- Calls `rmtree` on old column and block directories when writing a block manager to the same directory as a previous block manager
- Add tests for this functionality
- closes #127 