### PR TITLE
Fix issue where cell column materialize returns a cell column

### DIFF
--- a/meerkat/columns/cell_column.py
+++ b/meerkat/columns/cell_column.py
@@ -42,6 +42,23 @@ class CellColumn(AbstractColumn):
         else:
             return [self._data[i] for i in indices]
 
+    def _get(self, index, materialize: bool = True, _data: np.ndarray = None):
+        index = self._translate_index(index)
+        if isinstance(index, int):
+            if _data is None:
+                _data = self._get_cell(index, materialize=materialize)
+            return _data
+
+        elif isinstance(index, np.ndarray):
+            # support for blocks
+            if _data is None:
+                _data = self._get_batch(index, materialize=materialize)
+            if materialize:
+                # materialize could change the data in unknown ways, cannot clone
+                return self.__class__.from_data(data=_data)
+            else:
+                return self._clone(data=_data)
+
     @classmethod
     def from_cells(cls, cells: Sequence[AbstractCell], *args, **kwargs):
         return cls(cells=cells, *args, **kwargs)


### PR DESCRIPTION
Cannot clone when materialize is true because the data could change types. This is the same as what we had to do for LambdaColumn