### PR TITLE
Add args, kwargs to ColumnIOMixin._read_data

### DIFF
--- a/meerkat/mixins/io.py
+++ b/meerkat/mixins/io.py
@@ -85,5 +85,5 @@ class ColumnIOMixin:
             return dill.loads(dill_str)
 
     @staticmethod
-    def _read_data(path: str):
+    def _read_data(path: str, *args, **kwargs):
         return dill.load(open(os.path.join(path, "data.dill"), "rb"))


### PR DESCRIPTION
Co-authored-by: Jesse Vig <45317205+jessevig@users.noreply.github.com>

@krandiash enable this code to run without errors:
```
import meerkat as mk
import spacy

nlp = spacy.load("en_core_web_sm")
doc1 = nlp("Apple is looking at buying U.K. startup for $1 billion")
doc2 = nlp("Hello there")

dp = mk.DataPanel({
# 'text': ['The quick brown fox.', 'Jumped over.'],
# 'spacy': mk.SpacyColumn([doc1, doc2]),
'list': [{}, {}]
})

dp.write('meerkat.dataset')
dp2 = dp.read('meerkat.dataset', nlp=nlp)
```