### PR TITLE
Fix issue where arraycolumns can't be saved with jsonlines

### DIFF
--- a/meerkat/columns/tensor_column.py
+++ b/meerkat/columns/tensor_column.py
@@ -179,3 +179,10 @@ class TensorColumn(
 
     def to_tensor(self) -> torch.Tensor:
         return self.data
+
+    def to_pandas(self) -> pd.Series:
+        if len(self.shape) == 1:
+            return pd.Series(self.data)
+        else:
+            # can only create a 1-D series
+            return super().to_pandas()

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ REQUIRED = [
     "numpy>=1.18.0",
     "cytoolz",
     "ujson",
-    "jsonlines>=1.2.0",
     "torch>=1.8.0",
     "tqdm>=4.49.0",
     "datasets>=1.4.1",


### PR DESCRIPTION
Closes issue raised in #213. 
Simplified `to_jsonl` to simply wrap `to_pandas`, which addressed the issue. 